### PR TITLE
fix: make checkHasScaleCuda respect ffmpeg_path

### DIFF
--- a/packages/fast-preview/src/index.ts
+++ b/packages/fast-preview/src/index.ts
@@ -186,7 +186,7 @@ export default class FastPreview {
   }
 
   checkHasScaleCuda() {
-    const rst = spawnSync(`ffmpeg`, ["-hide_banner", "-filters"], {
+    const rst = spawnSync(`${FastPreview.ffmpeg_path}`, ["-hide_banner", "-filters"], {
       encoding: "utf8",
       windowsHide: true,
     });


### PR DESCRIPTION
Brings this check in line with all the others by honoring `FastPreview.ffmpeg_path`